### PR TITLE
Fix VNC canvas stretch

### DIFF
--- a/styling/styles.css
+++ b/styling/styles.css
@@ -9921,8 +9921,8 @@ body.map-none.embedded #vrm-tabs li.active {
 .remote-console-display-inner {
   position: relative;
   border: 1px solid #e5e4e0;
-  height: 272px;
-  width: 481px;
+  height: 274px;
+  width: 482px;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;


### PR DESCRIPTION
The container of the canvas was slightly smaller than the canvas itself leading to an image resize causing blur.