### PR TITLE
avoid async/await JS syntax to support old browsers

### DIFF
--- a/index.php
+++ b/index.php
@@ -206,25 +206,16 @@ function getSalt() {
 			attempt = 0;
 		};
 
-		// note: returns the url if it is...
-		async function isGuiv2Running() {
-			try {
-				const response = await fetch(location.protocol + "//" + location.hostname, {cache: "no-cache"});
-				if (response.ok) {
-					if (response.redirected && response.url.includes("gui-v2")) {
-						return response.url;
+		function checkGuiv2() {
+			fetch(location.protocol + "//" + location.hostname, {cache: "no-cache"})
+				.then(function(response) {
+					if (response.ok) {
+						if (response.redirected && response.url.includes("gui-v2")) {
+							location.replace(response.url)
+						}
 					}
-				}
-			} catch (error) {
-			}
-
-			return ""
-		}
-
-		async function checkGuiv2() {
-			const url = await isGuiv2Running();
-			if (url)
-				location.replace(url);
+				})
+				.catch(function(error) {})
 		}
 
 		function initRfb() {


### PR DESCRIPTION
This PR modifies commit https://github.com/victronenergy/javascript-vnc-client/commit/4923727ba2c745e97d2fef1285caea7ac6549a48 by replacing use of modern `async/await` JS syntax with traditional promise based callbacks to address https://github.com/victronenergy/venus/issues/1384.

I have tested that it parses correctly on Furuno and allows Remote Console to be loaded there, and that it does not emit any errors in the browser console. 

I have not tested if it behaves properly as I am not sure I understand what the logic behind this function is.